### PR TITLE
Handle absolute paths in YAML dataset loader

### DIFF
--- a/tests/test_yaml_dataset_loader.py
+++ b/tests/test_yaml_dataset_loader.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import yaml
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from yaml_dataset_loader import YamlDatasetLoader
+
+
+def test_absolute_paths(tmp_path):
+    images_dir = tmp_path / "images"
+    labels_dir = tmp_path / "labels"
+    images_dir.mkdir()
+    labels_dir.mkdir()
+    yaml_path = tmp_path / "data.yaml"
+    yaml_content = {
+        "train": str(images_dir),
+        "names": ["cls"],
+    }
+    yaml_path.write_text(yaml.dump(yaml_content))
+    loader = YamlDatasetLoader(str(yaml_path))
+    assert "train" in loader.get_dataset_splits()
+    paths = loader.get_paths("train")
+    assert paths["images"] == str(images_dir)
+    assert paths["labels"] == str(labels_dir)

--- a/yaml_dataset_loader.py
+++ b/yaml_dataset_loader.py
@@ -15,10 +15,13 @@ class YamlDatasetLoader:
 
         for split in ['train', 'val', 'test']:
             if split in data:
-                data[split] = data[split].lstrip("/")
-                images_path = os.path.abspath(os.path.join(self.root_dir, data[split]))
+                split_path = data[split]
+                if os.path.isabs(split_path):
+                    images_path = os.path.abspath(split_path)
+                else:
+                    images_path = os.path.abspath(os.path.join(self.root_dir, split_path))
                 labels_path = images_path.replace("images", "labels")
-                print(f"datasets:{split} -> {data[split]} / {images_path} / {labels_path}")
+                print(f"datasets:{split} -> {split_path} / {images_path} / {labels_path}")
                 if os.path.isdir(images_path) and os.path.isdir(labels_path):
                     print("Adding dataset keys")
                     self.datasets[split] = {


### PR DESCRIPTION
## Summary
- fix dataset path resolution to respect absolute paths
- add regression test ensuring absolute paths are accepted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976e4eda44832bb5aebdc5d8bf4fd1