### PR TITLE
Move image index display to dataset toolbar

### DIFF
--- a/image_viewer.py
+++ b/image_viewer.py
@@ -7,9 +7,10 @@ from bounding_box import BoundingBox
 
 
 class ImageViewer(tk.Frame):
-    def __init__(self, root, dataset):
+    def __init__(self, root, dataset, counter_callback=None):
         super().__init__(root)
         self.dataset = dataset
+        self.counter_callback = counter_callback
 
         self.boxes = []
         self.selected_box = None
@@ -68,6 +69,10 @@ class ImageViewer(tk.Frame):
         self.pan_x = 0
         self.pan_y = 0
         self.refresh()
+        if self.counter_callback:
+            idx = self.dataset.current_index() + 1
+            total = self.dataset.total_images()
+            self.counter_callback(idx, total)
 
     def refresh(self):
         self.canvas.delete("box")
@@ -86,14 +91,6 @@ class ImageViewer(tk.Frame):
             self.canvas.create_rectangle(x1, y1, x2, y2, outline=color, width=4, tag="box")
             self.canvas.create_text(x1 + 5, y1 + 10, text=box.class_name, fill=color, anchor="nw", tag="box")
 
-        # Draw current image index / total images at top right
-        idx = self.dataset.current_index() + 1
-        total = self.dataset.total_images()
-        text = f"{idx}/{total}"
-        self.canvas.create_text(
-            self.img_pil.width * self.zoom + self.pan_x - 10, 10 + self.pan_y,
-            text=text, fill="white", anchor="ne", font=("Arial", 16, "bold"), tag="box"
-        )
 
     def redraw_image(self):
         # Remove previous image

--- a/main.py
+++ b/main.py
@@ -45,11 +45,17 @@ class App:
             paths = self.yaml_loader.get_paths(split)
             self.datasets[split] = YoloDataset(paths["images"], paths["labels"], class_names)
 
-        # GUI dropdown to select split
-        self.split_selector = ttk.Combobox(root, values=list(self.datasets.keys()), state="readonly")
+        # GUI dropdown to select split and image counter
+        self.top_frame = tk.Frame(root)
+        self.top_frame.pack(pady=5)
+        self.split_selector = ttk.Combobox(
+            self.top_frame, values=list(self.datasets.keys()), state="readonly"
+        )
         self.split_selector.current(0)
-        self.split_selector.pack(pady=5)
+        self.split_selector.pack(side="left")
         self.split_selector.bind("<<ComboboxSelected>>", self.on_split_selected)
+        self.image_counter_label = tk.Label(self.top_frame, text="")
+        self.image_counter_label.pack(side="left", padx=10)
 
         # Frame for image viewer
         self.viewer_frame = tk.Frame(root)
@@ -63,13 +69,18 @@ class App:
         for widget in self.viewer_frame.winfo_children():
             widget.destroy()
 
-        self.viewer = ImageViewer(self.viewer_frame, self.current_dataset)
+        self.viewer = ImageViewer(
+            self.viewer_frame, self.current_dataset, self.update_image_counter
+        )
         self.viewer.pack(fill="both", expand=True)
 
     def on_split_selected(self, event=None):
         split = self.split_selector.get()
         self.current_dataset = self.datasets[split]
         self.load_viewer()
+
+    def update_image_counter(self, idx, total):
+        self.image_counter_label.config(text=f"{idx}/{total}")
 
 def parse_args():
     parser = argparse.ArgumentParser(description="AnnoQ - Simple Image Annotation Tool")


### PR DESCRIPTION
## Summary
- Show image index/total next to dataset selector instead of overlaying it on the canvas
- Provide callback from `ImageViewer` to update the counter when images change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4b768710832b9b9f6afd619a0dcc