### PR TITLE
Enforce minimum bounding box size

### DIFF
--- a/bounding_box.py
+++ b/bounding_box.py
@@ -29,3 +29,16 @@ class BoundingBox:
     def contains_point(self, x, y, img_w, img_h):
         x1, y1, x2, y2 = self.to_pixel_rect(img_w, img_h)
         return x1 <= x <= x2 and y1 <= y <= y2
+
+    @staticmethod
+    def from_pixel_coords(class_id, x0, y0, x1, y1, img_w, img_h, class_name=""):
+        """Create a bounding box from pixel coordinates if it meets the
+        minimum size requirement of 10x10 pixels. Returns ``None`` if the
+        box is too small."""
+        if abs(x1 - x0) < 10 or abs(y1 - y0) < 10:
+            return None
+        xc = ((x0 + x1) / 2) / img_w
+        yc = ((y0 + y1) / 2) / img_h
+        bw = abs(x1 - x0) / img_w
+        bh = abs(y1 - y0) / img_h
+        return BoundingBox(class_id, xc, yc, bw, bh, class_name)

--- a/image_viewer.py
+++ b/image_viewer.py
@@ -175,11 +175,11 @@ class ImageViewer(tk.Frame):
             zy = (event.y - self.pan_y) / self.zoom
             x1, y1 = zx, zy
             w, h = self.img_pil.width, self.img_pil.height
-            xc = ((x0 + x1) / 2) / w
-            yc = ((y0 + y1) / 2) / h
-            bw = abs(x1 - x0) / w
-            bh = abs(y1 - y0) / h
-            self.boxes.append(BoundingBox(0, xc, yc, bw, bh, self.dataset.class_names[0]))
+            box = BoundingBox.from_pixel_coords(
+                0, x0, y0, x1, y1, w, h, self.dataset.class_names[0]
+            )
+            if box:
+                self.boxes.append(box)
             self.start_draw = None
             self.refresh()
 
@@ -205,8 +205,13 @@ class ImageViewer(tk.Frame):
             delta = event.delta
         if self.dragging and self.selected_box:
             scale_factor = 1.1 if delta > 0 else 0.9
-            self.selected_box.width *= scale_factor
-            self.selected_box.height *= scale_factor
+            w, h = self.img_pil.width, self.img_pil.height
+            new_w = self.selected_box.width * scale_factor
+            new_h = self.selected_box.height * scale_factor
+            min_w = 10 / w
+            min_h = 10 / h
+            self.selected_box.width = max(new_w, min_w)
+            self.selected_box.height = max(new_h, min_h)
             self.refresh()
         else:
             # Zoom image at mouse pointer

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -24,3 +24,16 @@ def test_contains_point_outside():
     box = BoundingBox(class_id=0, x_center=0.5, y_center=0.5, width=0.2, height=0.4)
     img_w, img_h = 100, 200
     assert not box.contains_point(10, 10, img_w, img_h)
+
+
+def test_from_pixel_coords_rejects_small_box():
+    img_w = img_h = 100
+    box = BoundingBox.from_pixel_coords(0, 0, 0, 5, 5, img_w, img_h)
+    assert box is None
+
+
+def test_from_pixel_coords_creates_box():
+    img_w = img_h = 100
+    box = BoundingBox.from_pixel_coords(0, 10, 10, 30, 30, img_w, img_h, "test")
+    assert box is not None
+    assert box.to_pixel_rect(img_w, img_h) == (10, 10, 30, 30)


### PR DESCRIPTION
## Summary
- prevent creating boxes smaller than 10x10 pixels
- clamp box resizing to keep dimensions above 10x10 pixels
- add tests for pixel-coordinate box creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e4cec83c0832bbe8ec7cbc20f7ea0