### PR TITLE
Add editable image index navigation

### DIFF
--- a/image_viewer.py
+++ b/image_viewer.py
@@ -34,6 +34,13 @@ class ImageViewer(tk.Frame):
         tk.Button(ctrl_frame, text="← Prev", command=self.prev_image).pack(side="left")
         tk.Button(ctrl_frame, text="Next →", command=self.next_image).pack(side="left")
         tk.Button(ctrl_frame, text="Save", command=self.save_labels).pack(side="left")
+        tk.Label(ctrl_frame, text="Image").pack(side="left")
+        self.index_var = tk.StringVar(value="1")
+        idx_entry = tk.Entry(ctrl_frame, width=5, textvariable=self.index_var)
+        idx_entry.pack(side="left")
+        self.total_label = tk.Label(ctrl_frame, text=f"/{self.dataset.total_images()}")
+        self.total_label.pack(side="left")
+        idx_entry.bind("<Return>", self.on_index_change)
         self.canvas.bind("<Left>", lambda e: self.prev_image())
         self.canvas.bind("<Right>", lambda e: self.next_image())
         tk.Checkbutton(ctrl_frame, text="Show Boxes", variable=self.show_boxes, command=self.refresh).pack(side="left")
@@ -67,6 +74,8 @@ class ImageViewer(tk.Frame):
         self.zoom = 1.0
         self.pan_x = 0
         self.pan_y = 0
+        self.index_var.set(str(self.dataset.current_index() + 1))
+        self.total_label.config(text=f"/{self.dataset.total_images()}")
         self.refresh()
 
     def refresh(self):
@@ -271,6 +280,14 @@ class ImageViewer(tk.Frame):
     def on_pan_end(self, event):
         self.panning = False
         self.pan_start = None
+
+    def on_index_change(self, event=None):
+        try:
+            new_idx = int(self.index_var.get()) - 1
+        except ValueError:
+            return
+        self.dataset.set_index(new_idx)
+        self.load_image()
 
     def delete_selected(self, event=None):
         if self.selected_box:

--- a/tests/test_yolo_dataset.py
+++ b/tests/test_yolo_dataset.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+from yolo_dataset import YoloDataset
+
+def test_set_index():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        img_dir = os.path.join(tmpdir, 'images')
+        lbl_dir = os.path.join(tmpdir, 'labels')
+        os.makedirs(img_dir)
+        os.makedirs(lbl_dir)
+        for i in range(5):
+            open(os.path.join(img_dir, f'image_{i}.jpg'), 'w').close()
+            open(os.path.join(lbl_dir, f'image_{i}.txt'), 'w').close()
+        dataset = YoloDataset(img_dir, lbl_dir, [])
+        assert dataset.total_images() == 5
+        dataset.set_index(3)
+        assert dataset.current_index() == 3
+        dataset.set_index(10)
+        assert dataset.current_index() == 3
+        dataset.set_index(-1)
+        assert dataset.current_index() == 3

--- a/yolo_dataset.py
+++ b/yolo_dataset.py
@@ -47,6 +47,10 @@ class YoloDataset:
     def prev(self):
         if self.index > 0:
             self.index -= 1
+
+    def set_index(self, idx):
+        if 0 <= idx < len(self.image_paths):
+            self.index = idx
     
     def current_index(self):
         return self.index


### PR DESCRIPTION
## Summary
- Add editable index field to the image viewer so users can jump directly to a specific image
- Provide dataset method for setting image index
- Test dataset index navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e4dbb1448832b90eee2c828bbab69