### PR TITLE
Add cache for YAML image indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 *.pyc
+.annoq_cache.json

--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+CACHE_PATH = os.path.join(os.path.expanduser("~"), ".annoq_cache.json")
+MAX_ENTRIES = 10
+
+
+def _read_cache():
+    if os.path.exists(CACHE_PATH):
+        try:
+            with open(CACHE_PATH, "r") as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    return data
+        except Exception:
+            pass
+    return []
+
+
+def _write_cache(entries):
+    with open(CACHE_PATH, "w") as f:
+        json.dump(entries, f)
+
+
+def get_cached_index(yaml_path):
+    yaml_path = os.path.abspath(yaml_path)
+    entries = _read_cache()
+    for entry in entries:
+        if entry.get("yaml") == yaml_path:
+            return entry.get("index")
+    return None
+
+
+def update_cache(yaml_path, index):
+    yaml_path = os.path.abspath(yaml_path)
+    entries = _read_cache()
+    entries = [e for e in entries if e.get("yaml") != yaml_path]
+    entries.append({"yaml": yaml_path, "index": index})
+    if len(entries) > MAX_ENTRIES:
+        entries = entries[-MAX_ENTRIES:]
+    _write_cache(entries)

--- a/cache.py
+++ b/cache.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-CACHE_PATH = os.path.join(os.path.expanduser("~"), ".annoq_cache.json")
+# Store the cache file alongside the application's main script
+CACHE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".annoq_cache.json")
 MAX_ENTRIES = 10
 
 

--- a/image_viewer.py
+++ b/image_viewer.py
@@ -9,9 +9,10 @@ from coords import image_to_canvas_coords, canvas_to_image_coords
 
 
 class ImageViewer(tk.Frame):
-    def __init__(self, root, dataset):
+    def __init__(self, root, dataset, index_callback=None):
         super().__init__(root)
         self.dataset = dataset
+        self.index_callback = index_callback
 
         self.boxes = []
         self.selected_box = None
@@ -110,6 +111,8 @@ class ImageViewer(tk.Frame):
         self.index_var.set(str(self.dataset.current_index() + 1))
         self.total_label.config(text=f"/{self.dataset.total_images()}")
         self.refresh()
+        if self.index_callback:
+            self.index_callback(self.dataset.current_index())
         self.update_info_area()
 
     def update_info_area(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,20 @@
+import json
+import cache
+
+def test_cache_max_entries(tmp_path, monkeypatch):
+    tmp_file = tmp_path / "cache.json"
+    monkeypatch.setattr(cache, "CACHE_PATH", str(tmp_file))
+    # ensure starting empty
+    assert cache.get_cached_index("a.yaml") is None
+    cache.update_cache("a.yaml", 1)
+    assert cache.get_cached_index("a.yaml") == 1
+    # add 11 more entries to exceed limit
+    for i in range(11):
+        cache.update_cache(f"file{i}.yaml", i)
+    with open(tmp_file) as f:
+        data = json.load(f)
+    assert len(data) == 10
+    # 'a.yaml' should be evicted
+    assert cache.get_cached_index("a.yaml") is None
+    # latest entry should be present
+    assert cache.get_cached_index("file10.yaml") == 10


### PR DESCRIPTION
## Summary
- Remember last viewed image index per YAML dataset
- Limit cache to 10 most recent datasets
- Remove leftover PIL and cv2 imports in main module
- Test cache eviction behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f93dbcc50832ba893c8b9c6c7a6c7