### PR TITLE
Add Ctrl+S shortcut for saving labels

### DIFF
--- a/image_viewer.py
+++ b/image_viewer.py
@@ -71,6 +71,7 @@ class ImageViewer(tk.Frame):
         idx_entry.bind_all("<Return>", self.on_index_change)
         self.canvas.bind_all("<Left>", lambda e: self.prev_image())
         self.canvas.bind_all("<Right>", lambda e: self.next_image())
+        self.canvas.bind_all("<Control-s>", lambda e: self.save_labels())
         tk.Checkbutton(ctrl_frame, text="Show Boxes", variable=self.show_boxes, command=self.refresh).pack(side="left")
 
         self.canvas.bind_all("<Button-1>", lambda event: event.widget.focus_set())


### PR DESCRIPTION
## Summary
- Bind Ctrl+S keyboard shortcut to trigger saving of labels in image viewer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fb8b421fc832ba66e63de433df067