### PR TITLE
Preserve default key bindings while adding custom shortcuts

### DIFF
--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/image_viewer.py
+++ b/image_viewer.py
@@ -9,10 +9,12 @@ from coords import image_to_canvas_coords, canvas_to_image_coords
 
 
 class ImageViewer(tk.Frame):
-    def __init__(self, root, dataset, index_callback=None):
+    def __init__(self, root, dataset, index_callback=None, key_bindings=None):
         super().__init__(root)
         self.dataset = dataset
         self.index_callback = index_callback
+        self.key_bindings = key_bindings or {}
+        self.bound_keys = {}
 
         self.boxes = []
         self.selected_box = None
@@ -69,10 +71,10 @@ class ImageViewer(tk.Frame):
         self.total_label = tk.Label(ctrl_frame, text=f"/{self.dataset.total_images()}")
         self.total_label.pack(side="left")
         idx_entry.bind_all("<Return>", self.on_index_change)
-        self.canvas.bind_all("<Left>", lambda e: self.prev_image())
-        self.canvas.bind_all("<Right>", lambda e: self.next_image())
-        self.canvas.bind_all("<Control-s>", lambda e: self.save_labels())
         tk.Checkbutton(ctrl_frame, text="Show Boxes", variable=self.show_boxes, command=self.refresh).pack(side="left")
+
+        # Apply key bindings
+        self.bind_keys()
 
         self.canvas.bind_all("<Button-1>", lambda event: event.widget.focus_set())
         self.canvas.bind("<Button-1>", self.on_click)
@@ -115,6 +117,37 @@ class ImageViewer(tk.Frame):
         if self.index_callback:
             self.index_callback(self.dataset.current_index())
         self.update_info_area()
+
+    def bind_keys(self):
+        # Unbind previous keys
+        for keys in self.bound_keys.values():
+            for k in keys:
+                try:
+                    self.canvas.unbind_all(k)
+                except tk.TclError:
+                    pass
+        self.bound_keys = {}
+
+        mapping = {
+            'prev_image': self.prev_image,
+            'next_image': self.next_image,
+            'save_labels': self.save_labels,
+        }
+        for action, func in mapping.items():
+            keys = self.key_bindings.get(action, [])
+            bound = []
+            for k in keys:
+                try:
+                    self.canvas.bind_all(k, lambda e, f=func: f())
+                    bound.append(k)
+                except tk.TclError:
+                    # Skip invalid key sequences to avoid crashes
+                    print(f"Warning: invalid key binding '{k}' for {action}")
+            self.bound_keys[action] = bound
+
+    def update_key_bindings(self, key_bindings):
+        self.key_bindings = key_bindings
+        self.bind_keys()
 
     def update_info_area(self):
         image_name = os.path.basename(self.dataset.current_image_path())

--- a/settings_window.py
+++ b/settings_window.py
@@ -1,0 +1,95 @@
+import json
+import os
+import re
+import tkinter as tk
+
+SETTINGS_DIR = os.path.join(os.path.dirname(__file__), '.settings')
+SETTINGS_FILE = os.path.join(SETTINGS_DIR, 'keybindings.json')
+
+DEFAULT_BINDINGS = {
+    'prev_image': ['<Left>'],
+    'next_image': ['<Right>'],
+    'save_labels': ['<Control-s>'],
+}
+
+_BUTTON_RE = re.compile(r"<Button-(\d+)>$")
+
+
+def _filter_invalid(keys):
+    """Remove obviously invalid mouse button bindings."""
+    valid = []
+    for k in keys:
+        m = _BUTTON_RE.fullmatch(k)
+        if m:
+            num = int(m.group(1))
+            if 1 <= num <= 5:
+                valid.append(k)
+        else:
+            valid.append(k)
+    return valid
+
+def ensure_settings_dir():
+    os.makedirs(SETTINGS_DIR, exist_ok=True)
+
+def load_keybindings():
+    """Load key bindings from the settings file."""
+    ensure_settings_dir()
+    bindings = {action: keys[:] for action, keys in DEFAULT_BINDINGS.items()}
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE) as f:
+                data = json.load(f)
+            for action, defaults in DEFAULT_BINDINGS.items():
+                extra = _filter_invalid(data.get(action, []))
+                bindings[action] = list(dict.fromkeys(defaults + extra))
+            for action, extra in data.items():
+                if action not in bindings:
+                    bindings[action] = _filter_invalid(extra)
+        except Exception:
+            pass
+    return bindings
+
+def save_keybindings(bindings):
+    """Save key bindings to the settings file."""
+    ensure_settings_dir()
+    merged = {}
+    for action, defaults in DEFAULT_BINDINGS.items():
+        extra = _filter_invalid(bindings.get(action, []))
+        merged[action] = list(dict.fromkeys(defaults + extra))
+    for action, extra in bindings.items():
+        if action not in merged:
+            merged[action] = _filter_invalid(extra)
+    with open(SETTINGS_FILE, 'w') as f:
+        json.dump(merged, f, indent=2)
+    return merged
+
+class SettingsWindow(tk.Toplevel):
+    """A simple settings window to edit key bindings."""
+    def __init__(self, master, bindings, callback=None):
+        super().__init__(master)
+        self.title('Settings')
+        self.callback = callback
+        self.entries = {}
+
+        row = 0
+        for action, keys in bindings.items():
+            tk.Label(self, text=action).grid(row=row, column=0, padx=5, pady=5, sticky='e')
+            entry = tk.Entry(self, width=25)
+            entry.insert(0, ', '.join(keys))
+            entry.grid(row=row, column=1, padx=5, pady=5)
+            self.entries[action] = entry
+            row += 1
+
+        tk.Button(self, text='Save', command=self.save).grid(
+            row=row, column=0, columnspan=2, pady=10
+        )
+
+    def save(self):
+        new_bindings = {}
+        for action, entry in self.entries.items():
+            keys = [k.strip() for k in entry.get().split(',') if k.strip()]
+            new_bindings[action] = _filter_invalid(keys)
+        merged = save_keybindings(new_bindings)
+        if self.callback:
+            self.callback(merged)
+        self.destroy()

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -1,0 +1,38 @@
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import settings_window as sw
+
+
+def test_default_bindings_retained(tmp_path, monkeypatch):
+    settings_dir = tmp_path / '.settings'
+    settings_file = settings_dir / 'keybindings.json'
+    monkeypatch.setattr(sw, 'SETTINGS_DIR', str(settings_dir))
+    monkeypatch.setattr(sw, 'SETTINGS_FILE', str(settings_file))
+
+    # Load when file doesn't exist -> defaults
+    bindings = sw.load_keybindings()
+    assert bindings == sw.DEFAULT_BINDINGS
+
+    # Save custom binding and ensure defaults persist
+    sw.save_keybindings({'prev_image': ['a']})
+    bindings = sw.load_keybindings()
+    assert '<Left>' in bindings['prev_image']
+    assert 'a' in bindings['prev_image']
+
+    # Attempt to remove default key; it should remain
+    sw.save_keybindings({'prev_image': []})
+    bindings = sw.load_keybindings()
+    assert '<Left>' in bindings['prev_image']
+
+
+def test_invalid_button_filtered(tmp_path, monkeypatch):
+    settings_dir = tmp_path / '.settings'
+    settings_file = settings_dir / 'keybindings.json'
+    monkeypatch.setattr(sw, 'SETTINGS_DIR', str(settings_dir))
+    monkeypatch.setattr(sw, 'SETTINGS_FILE', str(settings_file))
+
+    sw.save_keybindings({'save_labels': ['<Button-9>']})
+    bindings = sw.load_keybindings()
+    assert '<Button-9>' not in bindings['save_labels']
+    assert '<Control-s>' in bindings['save_labels']


### PR DESCRIPTION
## Summary
- Skip invalid key sequences when binding shortcuts to prevent Tkinter errors
- Filter out unsupported mouse button bindings in settings load/save routines
- Test that invalid bindings are ignored while defaults persist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a065a3c770832b883caa905ffd2b72