### PR TITLE
Add inference overlay and model CLI option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 opencv-python
 pillow
 pyyaml
+ultralytics


### PR DESCRIPTION
## Summary
- Add top-right **Inference** button that loads a YOLO model and shows predictions in an overlay window
- Keep overlay active across image navigation and stop inference once the window is closed
- Support `--model` CLI argument and include `ultralytics` dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0dc5df4c4832bb04c2c0af8d2a942